### PR TITLE
error arc + warning __block redefined

### DIFF
--- a/UzysSlideMenu/Library/ARCHelper.h
+++ b/UzysSlideMenu/Library/ARCHelper.h
@@ -18,10 +18,11 @@
 #define ah_dealloc self
 #define release self
 #define autorelease self
-#define __block __weak
+#define ah__block __weak
 #else
 #define ah_retain retain
 #define ah_dealloc dealloc
+#define ah__block __block
 #define __bridge
 #endif
 #endif

--- a/UzysSlideMenu/Library/UzysSMMenuItemView.m
+++ b/UzysSlideMenu/Library/UzysSMMenuItemView.m
@@ -50,7 +50,7 @@
 -(void)setItem:(UzysSMMenuItem *)item
 {
     [_item release];
-    _item = [item retain];
+    _item = [item ah_retain];
     _imageView.image = item.image;
     _label.text = item.title;
     

--- a/UzysSlideMenu/Library/UzysSlideMenu.h
+++ b/UzysSlideMenu/Library/UzysSlideMenu.h
@@ -22,6 +22,7 @@ typedef enum _UzysSMState {
 @property (nonatomic,readonly) UzysSMState menuState;
 - (id)initWithItems:(NSArray *)items;
 - (void)toggleMenu;
+- (void)toggleMenuWithCompletion:(void(^)(UzysSMState state))block;
 - (void)openIconMenu;
 
 

--- a/UzysSlideMenu/Library/UzysSlideMenu.m
+++ b/UzysSlideMenu/Library/UzysSlideMenu.m
@@ -92,6 +92,13 @@
     }
 
 }
+- (void)toggleMenuWithCompletion:(void(^)(UzysSMState state))block
+{
+    [self toggleMenu];
+    
+    if (block) block(self.menuState);
+}
+
 #pragma mark - MenuState
 
 -(void)showIconMenu:(BOOL)animation


### PR DESCRIPTION
just fix little mistakes.

`retain ~> ah_retain` to fix error
and you redefined `__block` and xCode fires a warning
so, I called it `ah__block`

Actually, I don't think you need to redefined it..
because there are no called to `__block` in your library.

The user who used `UzysSlideMenu` is the person
who can use `__block`  in his code.
Thus, if he know what he does,
he has to use `__block` or `__weak` and it doesn't affect your library.
